### PR TITLE
Fix errors with ansible3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
-ansible==2.9.6
+ansible==3.1.0
 pylint==2.7.2
 yamllint==1.26.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,7 @@
 ---
-
 - name: Validate Ansible variables using the provided YAML schema
   vars_schema_validator:
-    var: '{{ vars }}'
+    var: '{{ vars | to_json }}'
     schema: '{{ schema }}'
   register: validation_result
 


### PR DESCRIPTION
Fix the error caused by ansible3 upgrade.

The error shows as follow:
`
TASK [vars_schema_validator : Validate Ansible variables using the provided YAML schema] *****************************************************
fatal: [localhost]: FAILED! => changed=false
  msg: 'argument var is of type <class ''str''> and we were unable to convert to dict: unable to evaluate string as dictionary'
`
